### PR TITLE
Random improvements, mostly to the state handling api

### DIFF
--- a/lib/alice/handlers/random.ex
+++ b/lib/alice/handlers/random.ex
@@ -111,12 +111,12 @@ defmodule Alice.Handlers.Random do
   end
   def handle(conn, :haha) do
     conn
-    |> Alice.Conn.get_state_for({__MODULE__, :haha}, 0)
+    |> get_state(:haha_count, 0)
     |> case do
       93 ->
         "https://s3.amazonaws.com/giphymedia/media/Ic97mPViHEG5O/giphy.gif"
-        |> reply(Alice.Conn.put_state_for(conn, {__MODULE__, :haha}, 0))
-      count -> Alice.Conn.put_state_for(conn, {__MODULE__, :haha}, count + 1)
+        |> reply(put_state(conn, :haha_count, 0))
+      count -> put_state(conn, :haha_count, count + 1)
     end
   end
 end

--- a/lib/alice/handlers/utils.ex
+++ b/lib/alice/handlers/utils.ex
@@ -17,9 +17,7 @@ defmodule Alice.Handlers.Utils do
   def handle(conn, :debug_slack), do: inspect(conn.slack)|> format_code |> reply(conn)
   def handle(conn, :debug_conn),  do: inspect(conn)|> format_code |> reply(conn)
 
-  @doc """
-  Formats code for Slack
-  """
+  # Formats code for Slack
   defp format_code(code) do
     """
     ```

--- a/lib/alice/router.ex
+++ b/lib/alice/router.ex
@@ -85,6 +85,8 @@ defmodule Alice.Router do
       Module.register_attribute __MODULE__, :routes, accumulate: true
       Module.register_attribute __MODULE__, :commands, accumulate: true
       @before_compile Alice.Router.Helpers
+
+      defp namespace(key), do: {__MODULE__, key}
     end
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -3,7 +3,7 @@ defmodule Alice.Mixfile do
 
   def project do
     [app: :alice,
-     version: "0.0.2",
+     version: "0.0.3",
      elixir: "~> 1.2",
      build_embedded: Mix.env == :prod,
      start_permanent: Mix.env == :prod,

--- a/test/alice/router/helpers_test.exs
+++ b/test/alice/router/helpers_test.exs
@@ -1,4 +1,4 @@
-defmodule Slack do
+defmodule FakeSlack do
   def send_message(text, :channel, :slack) do
     send(self, {:msg, text})
   end

--- a/test/alice/router_test.exs
+++ b/test/alice/router_test.exs
@@ -1,7 +1,8 @@
 defmodule TestHandler do
   use Alice.Router
 
-  def match(_routes, _conn), do: send(self, :received)
+  # overwrite match for testing purposes
+  defp match(_routes, _conn), do: send(self, :received)
 
   route ~r/pattern/, :my_route
 end
@@ -32,5 +33,16 @@ defmodule Alice.RouterTest do
   test "match_routes calls match_routes on each handler" do
     Router.match_routes(:fake_conn)
     assert_received :received
+  end
+
+  test "it can put state" do
+    conn = Alice.Conn.make(:msg, :slk)
+    conn = TestHandler.put_state(conn, :key, :val)
+    assert conn.state == %{{TestHandler, :key} => :val}
+  end
+
+  test "it can get state" do
+    conn = Alice.Conn.make(:msg, :slk, %{{TestHandler, :key} => :val})
+    assert :val == TestHandler.get_state(conn, :key)
   end
 end


### PR DESCRIPTION
Now you can use `get_state` and `put_state` in handlers. This namespaces the state data to each handler.

Example:

``` elixir
defmodule Alice.Handlers.Hello do
  use Alice.Router

  route ~r/hello/, :hello

  def handle(conn, :hello) do
    count = get_state(conn, :hello_count, 1)
    "You have said 'hello' #{count} times."
    |> reply(put_state(conn, :hello_count, count + 1))
  end
end
```

This will save the state as

``` elixir
%Alice.Conn{state: %{{Alice.Handlers.Hello, :hello_count} => 3}}
```
