### PR TITLE
Message Sanitation

### DIFF
--- a/lib/alice/bot.ex
+++ b/lib/alice/bot.ex
@@ -29,6 +29,7 @@ defmodule Alice.Bot do
   # Handle messages from subscribed channels
   def handle_message(message = %{type: "message"}, slack, state) do
     conn = {message, slack, state} |> Alice.Conn.make
+                                   |> Alice.Conn.sanitize_message
     conn = cond do
       Alice.Earmuffs.blocked?(conn) -> Alice.Earmuffs.unblock(conn)
       Alice.Conn.command?(conn)     -> Alice.Router.match_commands(conn)

--- a/lib/alice/conn.ex
+++ b/lib/alice/conn.ex
@@ -68,6 +68,38 @@ defmodule Alice.Conn do
   end
 
   @doc """
+  Used internally to sanitize the incoming message text
+  """
+  def sanitize_message(conn=%__MODULE__{message: message=%{text: text}}) do
+    message
+    |> Map.put(:original_text, text)
+    |> Map.put(:text, sanitize_text(text))
+    |> make(conn.slack, conn.state)
+  end
+
+  defp sanitize_text(text) do
+    text
+    |> remove_smart_quotes
+    |> remove_formatted_emails
+    |> remove_formatted_urls
+  end
+
+  defp remove_smart_quotes(text) do
+    text
+    |> String.replace(~s(“), ~s("))
+    |> String.replace(~s(”), ~s("))
+    |> String.replace(~s(’), ~s('))
+  end
+
+  defp remove_formatted_emails(text) do
+    text |> String.replace(~r/<mailto:([^|]+)[^\s]*>/i, "\\1")
+  end
+
+  defp remove_formatted_urls(text) do
+    text |> String.replace(~r/<([^|@]+)([^\s]*)?>/, "\\1")
+  end
+
+  @doc """
   Used internally to get namespaced state
   """
   def get_state_for(conn=%__MODULE__{}, namespace, default \\ nil) do


### PR DESCRIPTION
Slack reformats messages adding smart quotes, and formatting url and email links. This adds a function to reformat the message so that it is easier for handlers to deal with.
