### PR TITLE
Rename Alice.Bot to Alice.ChatBackends.Slack

### DIFF
--- a/lib/alice.ex
+++ b/lib/alice.ex
@@ -28,7 +28,7 @@ defmodule Alice do
     import Supervisor.Spec, warn: false
     state_backend_children ++ [
       worker(Alice.Router, [handlers(extras)]),
-      worker(Alice.Bot, [])
+      worker(Alice.ChatBackends.Slack, [])
     ]
   end
 

--- a/lib/alice/chat_backends/slack.ex
+++ b/lib/alice/chat_backends/slack.ex
@@ -1,4 +1,4 @@
-defmodule Alice.Bot do
+defmodule Alice.ChatBackends.Slack do
   @moduledoc "Adapter for Slack"
   use Slack
 


### PR DESCRIPTION
This is preparation for a larger refactoring to add support for chat backends that can be specified in the config file for an Alice instance.

The `Bot` class will still needed for storing state and will be restored in a different form in a later revision.
