### PR TITLE
Make application initialization take a struct

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ def application do
   [ applications: [:alice],
     mod: {
       Alice, %{
-        :handlers => [
+        handlers: [
           Alice.Handlers.Random,
           Alice.Handlers.AgainstHumanity,
           Alice.Handlers.GoogleImages

--- a/README.md
+++ b/README.md
@@ -82,11 +82,15 @@ handler. We recommend putting them in `lib/alice/handlers/`.)
 def application do
   [ applications: [:alice],
     mod: {
-      Alice, [
-        Alice.Handlers.Random,
-        Alice.Handlers.AgainstHumanity,
-        Alice.Handlers.GoogleImages
-      ] } ]
+      Alice, %{
+        :handlers => [
+          Alice.Handlers.Random,
+          Alice.Handlers.AgainstHumanity,
+          Alice.Handlers.GoogleImages
+        ]
+      }
+    }
+  ]
 end
 ```
 

--- a/lib/alice.ex
+++ b/lib/alice.ex
@@ -6,10 +6,10 @@ defmodule Alice do
   List of Alice route handlers to register upon startup
   """
   def handlers(extras) do
-    [Alice.Earmuffs,
-     Alice.Handlers.Help,
-     Alice.Handlers.Utils
-    ] ++ extras
+    case Map.fetch(extras, :handlers) do
+      {:ok, additional_handlers} -> default_handlers ++ additional_handlers
+      _ -> default_handlers
+    end
   end
 
   @doc """
@@ -37,5 +37,9 @@ defmodule Alice do
       :redis -> [Supervisor.Spec.supervisor(Alice.StateBackends.RedixPool, [])]
       _other -> []
     end
+  end
+
+  defp default_handlers do
+    [Alice.Earmuffs, Alice.Handlers.Help, Alice.Handlers.Utils ]
   end
 end

--- a/test/alice_test.exs
+++ b/test/alice_test.exs
@@ -1,4 +1,18 @@
 defmodule AliceTest do
   use ExUnit.Case, async: true
   doctest Alice
+
+  alias Alice.Handlers.TestHandler
+
+  test "contains a default set of handlers" do
+    assert [Alice.Earmuffs, Alice.Handlers.Help, Alice.Handlers.Utils] == Alice.handlers(%{})
+  end
+
+  test "properly adds handlers to the list when they're provided" do
+    assert [Alice.Earmuffs,
+            Alice.Handlers.Help,
+            Alice.Handlers.Utils,
+            Alice.Handlers.TestHandler] ==
+          Alice.handlers(%{:handlers => [TestHandler]})
+  end
 end

--- a/test/alice_test.exs
+++ b/test/alice_test.exs
@@ -13,6 +13,6 @@ defmodule AliceTest do
             Alice.Handlers.Help,
             Alice.Handlers.Utils,
             Alice.Handlers.TestHandler] ==
-          Alice.handlers(%{:handlers => [TestHandler]})
+          Alice.handlers(%{handlers: [TestHandler]})
   end
 end


### PR DESCRIPTION
This explicitly names the thing that's being passed in when initializing the Alice application in another elixir app. It also sets things up so that either state backends or chat backends could be specified in the same struct (but that's future stuff).

This is a breaking change. Backwards compatibility is not kept.

README is updated. Do we need to update any other documentation before merging this PR?
