### PR TITLE
Extract image handling from the routing helpers

### DIFF
--- a/lib/alice/images.ex
+++ b/lib/alice/images.ex
@@ -1,0 +1,15 @@
+defmodule Alice.Images do
+  def uncache(potential_image) do
+    ~w[gif png jpg jpeg]
+    |> Enum.any?(&(potential_image |> String.downcase |> String.ends_with?(&1)))
+    |> case do
+      true -> "#{potential_image}##{random_tag}"
+      _    -> potential_image
+    end
+  end
+
+  defp random_tag do
+    "0." <> tag = to_string(:rand.uniform)
+    tag
+  end
+end

--- a/lib/alice/router/helpers.ex
+++ b/lib/alice/router/helpers.ex
@@ -22,23 +22,9 @@ defmodule Alice.Router.Helpers do
   def reply(conn = %Conn{}, resp) when is_list(resp), do: random_reply(conn, resp)
   def reply(conn = %Conn{message: %{channel: channel}, slack: slack}, resp) do
     resp
-    |> uncache_images
+    |> Alice.Images.uncache
     |> slack_api.send_message(channel, slack)
     conn
-  end
-
-  defp uncache_images(potential_image) do
-    ~w[gif png jpg jpeg]
-    |> Enum.any?(&(potential_image |> String.downcase |> String.ends_with?(&1)))
-    |> case do
-      true -> "#{potential_image}##{random_tag}"
-      _    -> potential_image
-    end
-  end
-
-  defp random_tag do
-    "0." <> tag = to_string(:rand.uniform)
-    tag
   end
 
   defp slack_api do

--- a/test/alice/images_test.exs
+++ b/test/alice/images_test.exs
@@ -1,0 +1,13 @@
+defmodule Alice.ImagesTest do
+  use ExUnit.Case, async: true
+
+  test "does not provide a random tag for non-image urls" do
+    potential_image = "http://example.com/example.txt"
+    assert potential_image == Alice.Images.uncache(potential_image)
+  end
+
+  test "provides a random tag for non-image urls" do
+    potential_image = "http://example.com/fancy_image.jpg"
+    refute String.ends_with?(Alice.Images.uncache(potential_image), ["jpg"])
+  end
+end


### PR DESCRIPTION
I've decided that helper modules in Elixir are an anti-pattern and am
now extracting things out of Alice.Router.Helpers into their own
modules.

This is the first one. :smiley:
