### PR TITLE
Use bot name in help handler

### DIFF
--- a/lib/alice/conn.ex
+++ b/lib/alice/conn.ex
@@ -45,7 +45,9 @@ defmodule Alice.Conn do
   @doc """
   Returns the name of the bot
   """
-  def bot_name(conn), do: conn.slack.me.name
+  def bot_name(conn = %Conn{}) do
+    conn.slack.me.name
+  end
 
   @doc """
   Builds a string to use as an @reply back to the user who sent the message

--- a/lib/alice/conn.ex
+++ b/lib/alice/conn.ex
@@ -43,6 +43,11 @@ defmodule Alice.Conn do
   end
 
   @doc """
+  Returns the name of the bot
+  """
+  def bot_name(conn), do: conn.slack.me.name
+
+  @doc """
   Builds a string to use as an @reply back to the user who sent the message
   """
   def at_reply_user(conn = %Conn{}) do

--- a/lib/alice/handlers/help.ex
+++ b/lib/alice/handlers/help.ex
@@ -3,7 +3,6 @@ defmodule Alice.Handlers.Help do
   use Alice.Router
   alias Alice.Router
   alias Alice.Conn
-  require IEx
 
   command ~r/>:? help\z/i, :general_help
   command ~r/\bhelp (.*)\z/i, :keyword_help

--- a/lib/alice/handlers/help.ex
+++ b/lib/alice/handlers/help.ex
@@ -3,6 +3,7 @@ defmodule Alice.Handlers.Help do
   use Alice.Router
   alias Alice.Router
   alias Alice.Conn
+  require IEx
 
   command ~r/>:? help\z/i, :general_help
   command ~r/\bhelp (.*)\z/i, :keyword_help
@@ -13,8 +14,8 @@ defmodule Alice.Handlers.Help do
   def general_help(conn) do
     ["_Here are all the handlers I know about…_",
      handler_list(),
-     "_Get info about a specific handler with_ `@alice help <handler name>`",
-     "_Get info about all handlers with_ `@alice help all`",
+     "_Get info about a specific handler with_ `@#{Conn.bot_name(conn)} help <handler name>`",
+     "_Get info about all handlers with_ `@#{Conn.bot_name(conn)} help all`",
     "_Feedback on Alice is appreciated. Please submit an issue at https://github.com/alice-bot/alice/issues _"]
     |> Enum.join("\n\n")
     |> reply(conn)
@@ -31,7 +32,7 @@ defmodule Alice.Handlers.Help do
   defp do_keyword_help(conn, "all") do
     [@pro_tip,
      "_Here are all the routes and commands I know about…_"
-     | Enum.map(Router.handlers, &help_for_handler/1)]
+     | Enum.map(Router.handlers, &help_for_handler/2)]
     |> Enum.reduce(conn, &reply/2)
   end
   defp do_keyword_help(conn, term) do
@@ -78,15 +79,15 @@ defmodule Alice.Handlers.Help do
   defp deliver_help(handler, conn) do
     [ @pro_tip,
       ~s(_Here are all the routes and commands I know for "#{get_term(conn)}"_),
-      help_for_handler(handler) ]
+      help_for_handler(handler, conn) ]
     |> Enum.join("\n\n")
     |> reply(conn)
   end
 
-  def help_for_handler(handler) do
+  def help_for_handler(handler, conn) do
     [ ">*#{path_name(handler)}*",
-      format_routes("Routes", handler.routes, handler),
-      format_routes("Commands", handler.commands, handler), "" ]
+      format_routes("Routes", handler.routes, handler, conn),
+      format_routes("Commands", handler.commands, handler, conn), "" ]
     |> compact()
     |> Enum.join("\n")
   end
@@ -94,38 +95,38 @@ defmodule Alice.Handlers.Help do
   defp path_name("Elixir." <> name), do: name
   defp path_name(handler), do: handler |> to_string() |> path_name()
 
-  defp format_routes(_,[],_), do: nil
-  defp format_routes(title, routes, handler) do
+  defp format_routes(_,[],_,_), do: nil
+  defp format_routes(title, routes, handler, conn) do
     routes = Enum.map(routes, fn({_,name}) -> name end)
 
     docs = handler
-           |> Code.get_docs(:docs)
-           |> Stream.map(fn({{name,_},_,_,_,text}) -> {title, name, text} end)
-           |> Stream.filter(fn({_,name,_}) -> name in routes end)
-           |> Enum.map(&format_route/1)
-           |> compact()
+      |> Code.get_docs(:docs)
+      |> Stream.map(fn({{name,_},_,_,_,text}) -> {title, name, text, conn} end)
+      |> Stream.filter(fn({_,name,_,conn}) -> name in routes end)
+      |> Enum.map(&format_route/1)
+      |> compact()
 
     [">", "> *#{title}:*" | docs]
     |> Enum.join("\n")
   end
 
-  defp format_route({_,_,false}), do: nil
-  defp format_route({title, name, text}) do
-    [">    _#{name}_", format_text(text, title)]
+  defp format_route({_,_,false,_}), do: nil
+  defp format_route({title, name, text, conn}) do
+    [">    _#{name}_", format_text(text, title, conn)]
     |> Enum.join("\n")
   end
 
-  defp format_text(nil,_), do: ">        _no documentation provided_"
-  defp format_text(text, title) do
+  defp format_text(nil,_,_), do: ">        _no documentation provided_"
+  defp format_text(text, title, conn) do
     text
     |> String.trim()
     |> String.split("\n")
-    |> Stream.map(fn(line) -> ">        #{prefix_command(title, line)}" end)
+    |> Stream.map(fn(line) -> ">        #{prefix_command(title, line, conn)}" end)
     |> Enum.join("\n")
   end
 
-  defp prefix_command("Commands", "`" <> line), do: "`@alice #{line}"
-  defp prefix_command(_, line), do: line
+  defp prefix_command("Commands", "`" <> line, conn), do: "`@#{Conn.bot_name(conn)} #{line}"
+  defp prefix_command(_, line, _), do: line
 
   defp compact(list), do: list |> Enum.reject(&is_nil/1)
 end

--- a/test/alice/handlers/help_test.exs
+++ b/test/alice/handlers/help_test.exs
@@ -4,7 +4,16 @@ defmodule Alice.Handlers.HelpTest do
   alias Alice.Handlers.TestHandler
 
   test "help_for_handler generates the correct output" do
-    assert Help.help_for_handler(TestHandler, %{slack: %{me: %{name: "alice"}}}) ==
+    conn = Alice.Conn.make(%{}, %{me: %{name: "alice"}})
+    assert Help.help_for_handler(TestHandler, conn) == test_help_message_output(conn)
+  end
+
+  test "help_for_handler generates the correct output with a different bot name" do
+    conn = Alice.Conn.make(%{}, %{me: %{name: "mad_hatter"}})
+    assert Help.help_for_handler(TestHandler, conn) == test_help_message_output(conn)
+  end
+
+  defp test_help_message_output(%Alice.Conn{slack: %{me: %{name: bot_name}}}) do
     """
     >*Alice.Handlers.TestHandler*
     >
@@ -14,9 +23,9 @@ defmodule Alice.Handlers.HelpTest do
     >
     > *Commands:*
     >    _command1_
-    >        `@alice cmd1`: does some stuff
+    >        `@#{bot_name} cmd1`: does some stuff
     >    _command2_
-    >        `@alice cmd2`: does some other stuff
+    >        `@#{bot_name} cmd2`: does some other stuff
     >        also this one is multiline
     >    _command3_
     >        this one doesn't start with an

--- a/test/alice/handlers/help_test.exs
+++ b/test/alice/handlers/help_test.exs
@@ -4,7 +4,7 @@ defmodule Alice.Handlers.HelpTest do
   alias Alice.Handlers.TestHandler
 
   test "help_for_handler generates the correct output" do
-    assert Help.help_for_handler(TestHandler) ==
+    assert Help.help_for_handler(TestHandler, %{slack: %{me: %{name: "alice"}}}) ==
     """
     >*Alice.Handlers.TestHandler*
     >


### PR DESCRIPTION
Currently when using the `help` handler it has the bot name hard coded to `@alice`. If you don't name your bot alice then the help context doesn't make sense.

This PR adds `bot_name/1` that takes the `conn` and will returns the bot's slack name. 
<img src="https://user-images.githubusercontent.com/977174/39106298-9bc635fa-466f-11e8-90c1-1178dd54e249.png" alt="general help" width="250" height="250">
<img src="https://user-images.githubusercontent.com/977174/39106250-4b44ce5c-466f-11e8-9a47-032aaf8ed0b4.png" alt="handle helper" width="250" height="250">



 