### PR TITLE
Fix indentation

### DIFF
--- a/lib/alice/router.ex
+++ b/lib/alice/router.ex
@@ -169,6 +169,6 @@ defmodule Alice.Router do
                         |> Enum.reduce({__MODULE__, conn}, &match_pattern/2)
         conn
       end
-      end
+    end
   end
 end


### PR DESCRIPTION
Found an extra indent inside of `router.ex`.