### PR TITLE
BUG: fix help handler

### DIFF
--- a/lib/alice/handlers/help.ex
+++ b/lib/alice/handlers/help.ex
@@ -47,9 +47,9 @@ defmodule Alice.Handlers.Help do
 
   defp handler_list do
     Router.handlers()
-    |> Stream.map(&handler_name/1)
+    |> Enum.map(&handler_name/1)
     |> Enum.sort()
-    |> Stream.map(&"> *#{&1}*")
+    |> Enum.map(&"> *#{&1}*")
     |> Enum.join("\n")
   end
 
@@ -136,7 +136,7 @@ defmodule Alice.Handlers.Help do
     text
     |> String.trim()
     |> String.split("\n")
-    |> Stream.map(fn line -> ">        #{prefix_command(title, line)}" end)
+    |> Enum.map(fn line -> ">        #{prefix_command(title, line)}" end)
     |> Enum.join("\n")
   end
 

--- a/lib/alice/handlers/help.ex
+++ b/lib/alice/handlers/help.ex
@@ -27,10 +27,10 @@ defmodule Alice.Handlers.Help do
   `help <handler name>` - outputs the help text for a single matching handler
   """
   def keyword_help(conn) do
-    do_keyword_help(conn, get_term(conn))
+    keyword_help(conn, get_term(conn))
   end
 
-  defp do_keyword_help(conn, "all") do
+  defp keyword_help(conn, "all") do
     [
       @pro_tip,
       "_Here are all the routes and commands I know about…_"
@@ -39,7 +39,7 @@ defmodule Alice.Handlers.Help do
     |> Enum.reduce(conn, &reply/2)
   end
 
-  defp do_keyword_help(conn, term) do
+  defp keyword_help(conn, term) do
     Router.handlers()
     |> Enum.find(&(downcased_handler_name(&1) == term))
     |> deliver_help(conn)


### PR DESCRIPTION
We had previously updated the help handler to account for the new format in elixir 1.7+, however, we had not accounted for the new format when it came to hidden docs and missing docs. This fixes that issue.