### PR TITLE
Include the formatter config in the package

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -34,7 +34,7 @@ defmodule Alice.Mixfile do
 
   defp package do
     [
-      files: ["lib", "config", "mix.exs", "README*"],
+      files: ["lib", "config", "mix.exs", "README*", ".formatter.exs"],
       maintainers: ["Adam Zaninovich"],
       licenses: ["MIT"],
       links: %{


### PR DESCRIPTION
This change exports the formatter config file so that other projects that use alice can import the formatter settings.

In handlers, for instance, alice provides some config to omit the parenthesis for `command/2` and `route/2`. If you want this behavior in your handler, just include `import_deps: [:alice]` in your `.formatter.exs` as described in [the formatter docs](https://hexdocs.pm/mix/master/Mix.Tasks.Format.html#module-importing-dependencies-configuration).