### PR TITLE
Feature/reply in threads

### DIFF
--- a/lib/alice/chat_backends/slack_outbound.ex
+++ b/lib/alice/chat_backends/slack_outbound.ex
@@ -9,7 +9,12 @@ defmodule Alice.ChatBackends.SlackOutbound do
     :ok
   end
 
-  @spec send_message(message :: String.t(), channel :: String.t(), slack :: map(), thread :: String.t()) :: :ok
+  @spec send_message(
+          message :: String.t(),
+          channel :: String.t(),
+          slack :: map(),
+          thread :: String.t()
+        ) :: :ok
   def send_message(message, channel, slack, thread) do
     Slack.Sends.send_message(message, channel, slack, thread)
     :ok

--- a/lib/alice/chat_backends/slack_outbound.ex
+++ b/lib/alice/chat_backends/slack_outbound.ex
@@ -9,6 +9,11 @@ defmodule Alice.ChatBackends.SlackOutbound do
     :ok
   end
 
+  def send_message(message, channel, slack, thread) do
+    Slack.Sends.send_message(message, channel, slack, thread)
+    :ok
+  end
+
   @doc "Makes Alice indicate she's typing in the appropriate channel"
   @spec indicate_typing(channel :: String.t(), slack :: map()) :: :ok
   def indicate_typing(channel, slack) do

--- a/lib/alice/chat_backends/slack_outbound.ex
+++ b/lib/alice/chat_backends/slack_outbound.ex
@@ -9,6 +9,7 @@ defmodule Alice.ChatBackends.SlackOutbound do
     :ok
   end
 
+  @spec send_message(message :: String.t(), channel :: String.t(), slack :: map(), thread :: String.t()) :: :ok
   def send_message(message, channel, slack, thread) do
     Slack.Sends.send_message(message, channel, slack, thread)
     :ok

--- a/lib/alice/router/helpers.ex
+++ b/lib/alice/router/helpers.ex
@@ -21,6 +21,14 @@ defmodule Alice.Router.Helpers do
   def reply(resp, conn = %Conn{}), do: reply(conn, resp)
   def reply(conn = %Conn{}, resp) when is_list(resp), do: random_reply(conn, resp)
 
+  def reply(conn = %Conn{message: %{channel: channel, thread_ts: thread}, slack: slack}, resp) do
+    resp
+    |> Alice.Images.uncache()
+    |> outbound_api().send_message(channel, slack, thread)
+
+    conn
+  end
+
   def reply(conn = %Conn{message: %{channel: channel}, slack: slack}, resp) do
     resp
     |> Alice.Images.uncache()

--- a/lib/alice/test/handlers_case.ex
+++ b/lib/alice/test/handlers_case.ex
@@ -59,6 +59,13 @@ defmodule Alice.HandlerCase do
     }
   end
 
+  @spec fake_conn_with_thread(String.t(), String.t()) :: conn()
+  def fake_conn_with_thread(thread \\ "fake thread", text \\ "") do
+    conn = %{message: message} = fake_conn(text)
+    message = Map.put(message, :thread_ts, thread)
+    Map.put(conn, :message, message)
+  end
+
   @doc """
   Generates a fake connection for testing purposes.
 

--- a/lib/alice/test/outbound_spy.ex
+++ b/lib/alice/test/outbound_spy.ex
@@ -11,9 +11,18 @@ defmodule Alice.ChatBackends.OutboundSpy do
     :ok
   end
 
-  @spec send_message(message :: String.t(), channel :: String.t(), slack :: map(), thread :: String.t()) :: :ok
+  @spec send_message(
+          message :: String.t(),
+          channel :: String.t(),
+          slack :: map(),
+          thread :: String.t()
+        ) :: :ok
   def send_message(message, channel, slack, thread) do
-    send(self(), {:send_message, %{response: message, channel: channel, slack: slack, thread: thread}})
+    send(
+      self(),
+      {:send_message, %{response: message, channel: channel, slack: slack, thread: thread}}
+    )
+
     :ok
   end
 

--- a/lib/alice/test/outbound_spy.ex
+++ b/lib/alice/test/outbound_spy.ex
@@ -6,8 +6,14 @@ defmodule Alice.ChatBackends.OutboundSpy do
 
   @doc "Sends the message back to the process so it can be retrieved later during the test"
   @spec send_message(message :: String.t(), channel :: String.t(), slack :: map()) :: :ok
-  def send_message(response, channel, slack) do
-    send(self(), {:send_message, %{response: response, channel: channel, slack: slack}})
+  def send_message(message, channel, slack) do
+    send(self(), {:send_message, %{response: message, channel: channel, slack: slack}})
+    :ok
+  end
+
+  @spec send_message(message :: String.t(), channel :: String.t(), slack :: map(), thread :: String.t()) :: :ok
+  def send_message(message, channel, slack, thread) do
+    send(self(), {:send_message, %{response: message, channel: channel, slack: slack, thread: thread}})
     :ok
   end
 

--- a/test/alice/handlers_case_test.exs
+++ b/test/alice/handlers_case_test.exs
@@ -48,6 +48,15 @@ defmodule Alice.HandlerCaseTest do
              )
   end
 
+  test "fake_conn_with_thread makes a conn with a thread", %{slack: slack} do
+    assert fake_conn_with_thread("fake thread", "message") ==
+             Conn.make(
+               %{channel: :channel, text: "message", user: "fake_user_id", thread_ts: "fake thread"},
+               slack,
+               %{}
+             )
+  end
+
   test "fake_conn makes a conn with state", %{slack: slack} do
     assert fake_conn("message", state: %{some: "state"}) ==
              Conn.make(

--- a/test/alice/handlers_case_test.exs
+++ b/test/alice/handlers_case_test.exs
@@ -51,7 +51,12 @@ defmodule Alice.HandlerCaseTest do
   test "fake_conn_with_thread makes a conn with a thread", %{slack: slack} do
     assert fake_conn_with_thread("fake thread", "message") ==
              Conn.make(
-               %{channel: :channel, text: "message", user: "fake_user_id", thread_ts: "fake thread"},
+               %{
+                 channel: :channel,
+                 text: "message",
+                 user: "fake_user_id",
+                 thread_ts: "fake thread"
+               },
                slack,
                %{}
              )

--- a/test/alice/router/helpers_test.exs
+++ b/test/alice/router/helpers_test.exs
@@ -6,10 +6,17 @@ defmodule Alice.Router.HelpersTest do
     assert reply("yo", fake_conn()) == fake_conn()
   end
 
-  test "reply sends a message with Slack.send_message" do
+  test "reply sends a message with Slack.send_message/3" do
     reply("yo", fake_conn())
 
     assert first_reply() == "yo"
+  end
+
+  test "reply sends a message to a thread with Slack.send_message/4" do
+    fake_conn = fake_conn_with_thread("fake thread")
+
+    conn = reply("yo", fake_conn)
+    assert conn.message.thread_ts == "fake thread"
   end
 
   test "multiple replies can be sent in the same handler" do


### PR DESCRIPTION
What is this?
---
This adds support to reply to threads in slack.

- Adds send_message/4 to SlackOutbound which accepts a thread
- Adds a new pattern match to Alice.Router.Helpers reply/2 which pattern matches on a thread and passes that to the new send_message/4 to reply to the thread

Further discussion may be needed.
For example this adds a new send_message/4 to the SlackOutbound API but does not require that the new send_message/4 is defined in the `Alice.ChatBackends.OutboundClient` behaviour. This may be desired if the supporting backend doesn't support threading. 

How to test this
---
Trigger a route or command in a slack thread, alice replies in that thread

<img src="https://user-images.githubusercontent.com/977174/91629837-47084a00-e981-11ea-841e-be0d179e1b00.png" alt="alt text" width="350" height="250">
<img src="https://user-images.githubusercontent.com/977174/91629862-6c955380-e981-11ea-9131-f0635d6bd28f.png" alt="alt text" width="350" height="250">

