### PR TITLE
Update tests for newer version Elixir

### DIFF
--- a/lib/alice/handlers/help.ex
+++ b/lib/alice/handlers/help.ex
@@ -134,7 +134,7 @@ defmodule Alice.Handlers.Help do
     {title, name, text}
   end
 
-  defp parse_function_doc({{:function, name, _arity}, _anno, _sig, :none, _meta}, title) do
+  defp parse_function_doc({{:function, name, _arity}, _anno, _sig, %{}, _meta}, title) do
     {title, name, :none}
   end
 

--- a/lib/alice/handlers/help.ex
+++ b/lib/alice/handlers/help.ex
@@ -138,6 +138,10 @@ defmodule Alice.Handlers.Help do
     {title, name, :none}
   end
 
+  defp parse_function_doc({{:function, name, _arity}, _anno, _sig, :none, _meta}, title) do
+    {title, name, :none}
+  end
+
   defp parse_function_doc({{:function, name, _arity}, _anno, _sig, :hidden, _meta}, title) do
     {title, name, :hidden}
   end

--- a/lib/alice/test/handlers_case.ex
+++ b/lib/alice/test/handlers_case.ex
@@ -218,7 +218,7 @@ defmodule Alice.HandlerCase do
       import Alice.HandlerCase
 
       setup do
-        Alice.Router.start_link(unquote(handlers))
+        start_supervised({Alice.Router, unquote(handlers)})
 
         :ok
       end

--- a/test/alice/console_test.exs
+++ b/test/alice/console_test.exs
@@ -5,7 +5,7 @@ defmodule Alice.ConsoleTest do
   import ExUnit.CaptureIO
 
   setup_all do
-    Alice.Router.start_link([Alice.Earmuffs, Alice.Handlers.Utils, Alice.Handlers.Help])
+    start_supervised({Alice.Router, [Alice.Earmuffs, Alice.Handlers.Utils, Alice.Handlers.Help]})
 
     on_exit(fn ->
       Application.put_env(:alice, :outbound_client, Alice.ChatBackends.OutboundSpy)

--- a/test/mix/tasks/alice/console_test.exs
+++ b/test/mix/tasks/alice/console_test.exs
@@ -4,7 +4,7 @@ defmodule Mix.Tasks.Alice.ConsoleTest do
   import ExUnit.CaptureIO
 
   setup_all do
-    Alice.Router.start_link([Alice.Handlers.Utils, Alice.Handlers.Help])
+    start_supervised({Alice.Router, [Alice.Handlers.Utils, Alice.Handlers.Help]})
 
     on_exit(fn ->
       Application.put_env(:alice, :outbound_client, Alice.ChatBackends.OutboundSpy)


### PR DESCRIPTION
- Favor `start_supervised`, to ensure processed are shutdown after test run
- Update function signature due to Elixir 1.12 changes
